### PR TITLE
Adds missing tests for restoring selections on inactive elements 

### DIFF
--- a/test/curse-test.js
+++ b/test/curse-test.js
@@ -28,13 +28,13 @@ describe('Curse', function() {
     });
 
     it('can restore a selection', function() {
-      window.getSelection().removeAllRanges();
+      clearCurrentSelection();
       curse.restore();
       assertSelected('o ba');
     });
 
     it('can offset a selection', function() {
-      window.getSelection().removeAllRanges();
+      clearCurrentSelection();
       curse.offset(1);
       curse.restore();
       assertSelected(' bar');
@@ -47,6 +47,20 @@ describe('Curse', function() {
 
       curse.nodeLength($e.firstChild).should.equal('CUSTOM');
     });
+
+    it('will not restore on an inactive element ', function() {
+      clearCurrentSelection();
+      $e.blur();
+      curse.restore();
+      assertNoSelection();
+    })
+
+    it('will restore on an inactive element if forced', function() {
+      clearCurrentSelection();
+      $e.blur();
+      curse.restore(false);
+      assertSelected('o ba');
+    })
   });
 
   describe('capturing and restoring a backwards selection', function() {
@@ -86,7 +100,7 @@ describe('Curse', function() {
     });
 
     it('can restore the selection', function() {
-      window.getSelection().removeAllRanges();
+      clearCurrentSelection();
       curse.restore();
       assertSelected('o bar b');
     });
@@ -106,7 +120,7 @@ describe('Curse', function() {
     });
 
     it('can restore the selection', function() {
-      window.getSelection().removeAllRanges();
+      clearCurrentSelection();
       curse.restore();
       assertSelected('oo\nbar\nb');
     });
@@ -130,6 +144,14 @@ function addRange(range, reverse) {
 
 function assertSelected(text) {
   window.getSelection().toString().should.eql(text);
+}
+
+function assertNoSelection() {
+  window.getSelection().toString().should.eql('');
+}
+
+function clearCurrentSelection() {
+  window.getSelection().removeAllRanges();
 }
 
 function createRange(anchor, focus) {

--- a/test/curse-test.js
+++ b/test/curse-test.js
@@ -14,14 +14,26 @@ describe('Curse', function() {
     $e.remove();
   });
 
-  describe('capturing and restoring over plaintext', function() {
-    beforeEach(function() {
-      $e.innerText = 'foo bar';
-      var range = createRange([$e.childNodes[0], 2], [$e.childNodes[0], 6]);
-      addRange(range);
+  describe('restoring on inactive elements', function() {
+    beforeEach(function() { setupForwardTextSelection($e, curse); });
+
+    it('will not restore selection on an inactive element', function() {
+      clearCurrentSelection();
+      $e.blur();
+      curse.restore();
+      assertNoSelection();
+    })
+
+    it('will restore selection on an inactive element if forced', function() {
+      clearCurrentSelection();
+      $e.blur();
+      curse.restore(onlyActive=false);
       assertSelected('o ba');
-      curse.capture();
-    });
+    })
+  });
+
+  describe('capturing and restoring over plaintext', function() {
+    beforeEach(function() { setupForwardTextSelection($e, curse); });
 
     it('can capture a selection', function() {
       [curse.start, curse.end].should.eql([2, 6]);
@@ -47,30 +59,10 @@ describe('Curse', function() {
 
       curse.nodeLength($e.firstChild).should.equal('CUSTOM');
     });
-
-    it('will not restore on an inactive element ', function() {
-      clearCurrentSelection();
-      $e.blur();
-      curse.restore();
-      assertNoSelection();
-    })
-
-    it('will restore on an inactive element if forced', function() {
-      clearCurrentSelection();
-      $e.blur();
-      curse.restore(false);
-      assertSelected('o ba');
-    })
   });
 
   describe('capturing and restoring a backwards selection', function() {
-    beforeEach(function() {
-      $e.innerText = 'foo bar';
-      var range = createRange([$e.childNodes[0], 2], [$e.childNodes[0], 6]);
-      addRange(range, true);
-      assertSelected('o ba');
-      curse.capture();
-    });
+    beforeEach(function() { setupReverseTextSelection($e, curse); });
 
     it('can capture a selection', function() {
       [curse.start, curse.end].should.eql([6, 2]);
@@ -88,11 +80,7 @@ describe('Curse', function() {
 
   describe('capturing and restoring spanning an HTML element', function() {
     beforeEach(function() {
-      $e.innerHTML = 'foo <b>bar</b> baz';
-      var range = createRange([$e.childNodes[0], 2], [$e.childNodes[2], 2]);
-      addRange(range);
-      assertSelected('o bar b');
-      curse.capture();
+      setupHTMLSpanningSelection($e, curse);
     });
 
     it('can capture the selection', function() {
@@ -108,11 +96,7 @@ describe('Curse', function() {
 
   describe('capturing and restoring spanning a newline', function() {
     beforeEach(function() {
-      $e.innerText = 'foo\nbar\nbaz';
-      var range = createRange([$e.childNodes[0], 1], [$e.childNodes[4], 1]);
-      addRange(range);
-      assertSelected('oo\nbar\nb');
-      curse.capture();
+      setupNewlingSpanningSelection($e, curse);
     });
 
     it('can capture the selection', function() {
@@ -159,4 +143,37 @@ function createRange(anchor, focus) {
   r.setStart(anchor[0], anchor[1]);
   r.setEnd(focus[0], focus[1]);
   return r;
+}
+
+// Test Fixtures
+function setupForwardTextSelection(el, curse) {
+  el.innerText = 'foo bar';
+  var range = createRange([el.childNodes[0], 2], [el.childNodes[0], 6]);
+  addRange(range);
+  assertSelected('o ba');
+  curse.capture();
+}
+
+function setupReverseTextSelection(el, curse) {
+  el.innerText = 'foo bar';
+  var range = createRange([el.childNodes[0], 2], [el.childNodes[0], 6]);
+  addRange(range, true);
+  assertSelected('o ba');
+  curse.capture();
+}
+
+function setupHTMLSpanningSelection(el, curse) {
+  el.innerHTML = 'foo <b>bar</b> baz';
+  var range = createRange([el.childNodes[0], 2], [el.childNodes[2], 2]);
+  addRange(range);
+  assertSelected('o bar b');
+  curse.capture();
+}
+
+function setupNewlingSpanningSelection(el, curse) {
+  el.innerText = 'foo\nbar\nbaz';
+  var range = createRange([el.childNodes[0], 1], [el.childNodes[4], 1]);
+  addRange(range);
+  assertSelected('oo\nbar\nb');
+  curse.capture();
 }

--- a/test/curse-test.js
+++ b/test/curse-test.js
@@ -96,7 +96,7 @@ describe('Curse', function() {
 
   describe('capturing and restoring spanning a newline', function() {
     beforeEach(function() {
-      setupNewlingSpanningSelection($e, curse);
+      setupNewlineSpanningSelection($e, curse);
     });
 
     it('can capture the selection', function() {
@@ -170,7 +170,7 @@ function setupHTMLSpanningSelection(el, curse) {
   curse.capture();
 }
 
-function setupNewlingSpanningSelection(el, curse) {
+function setupNewlineSpanningSelection(el, curse) {
   el.innerText = 'foo\nbar\nbaz';
   var range = createRange([el.childNodes[0], 1], [el.childNodes[4], 1]);
   addRange(range);


### PR DESCRIPTION
On reading the source I noticed there were no test for restoring a selection when the element is inactive, or forcing a restore on an inactive element. So I added them. :dancer: 

Also, I cleaned up some of the setup preamble into a Fixtures section, so that the tests would be clearer on first read. 
